### PR TITLE
Add actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,57 +1,21 @@
 name: Build and Test
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
         container: ["ubuntu:trusty", "ubuntu:xenial", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:latest", "ubuntu:devel"]
     container:
       image: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-          python-version: ${{ matrix.python-version }}
-    - name: Install dependencies and run tests
-      run: |
-        apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
-        python3 -V
-        python3 setup.py install
-
-  build-wheel:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:jammy
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build wheel package
-      run: |
-        apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
-        python3 -V
-        python3 setup.py bdist_wheel
-    - name: Upload wheel artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wheel-package
-        path: dist/*.whl
-
-  build-rpm:
-    runs-on: ubuntu-latest
-    container:
-      image: centos:7
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build RPM package
-      run: |
-        yum install -y python3 python3-pip rpm-build
-        python3 setup.py bdist_rpm
-    - name: Upload RPM artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: rpm-package
-        path: dist/*.rpm
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        run: |
+          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+          python3 -V
+      - name: Install dependencies
+        run: |
+          python3 setup.py install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11"]
         container: ["ubuntu:trusty", "ubuntu:xenial", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:latest", "ubuntu:devel"]
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Set up Python
         run: |
           apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,57 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        container: ["ubuntu:trusty", "ubuntu:xenial", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:latest", "ubuntu:devel"]
+    container:
+      image: ${{ matrix.container }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+          python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and run tests
+      run: |
+        apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+        python3 -V
+        python3 setup.py install
+
+  build-wheel:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build wheel package
+      run: |
+        apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+        python3 -V
+        python3 setup.py bdist_wheel
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheel-package
+        path: dist/*.whl
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build RPM package
+      run: |
+        yum install -y python3 python3-pip rpm-build
+        python3 setup.py bdist_rpm
+    - name: Upload RPM artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: rpm-package
+        path: dist/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v3
         with:
-          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
-          path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
-
+          # name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+          # path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
+          name: alpamon-1.1.4-py3-none-any.whl
+          path: dist/alpamon-1.1.4-py3-none-any.whl
 
   release:
     runs-on: ubuntu-latest
@@ -43,7 +44,8 @@ jobs:
       - name: Download wheel artifact
         uses: actions/download-artifact@v3
         with:
-          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+          # name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+          name: alpamon-1.1.4-py3-none-any.whl
 
       - name: List downloaded files
         run: ls
@@ -51,9 +53,8 @@ jobs:
       - name: Release to alpacon.io
         run: |
           alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
-          alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl    
-
-
+          alpacon package python upload alpamon-1.1.4-py3-none-any.whl
+#           alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl
 
 #  build-rpm:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           name: alpamon-${{ github.ref_name }}-py3-none-any.whl
 
+      - name: Download rpm artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: alpamon-${{ github.ref_name }}-1.noarch.rpm
+
       - name: Release to alpacon.io
         run: |
           alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: release
+on: push # test
+
+#on:
+#  push:
+#    # run only against tags
+#    tags:
+#      - "*"
+
+
+jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+          python3 -V
+
+      - name: Build wheel package
+        run: |
+          python3 setup.py bdist_wheel
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+          path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
+
+
+  release:
+    runs-on: ubuntu-latest
+    container:
+      image: alpacanetworks/alpacon-cli:latest
+      options: --entrypoint ""
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+
+      - name: List downloaded files
+        run: ls
+
+      - name: Release to alpacon.io
+        run: |
+          alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
+          alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl    
+
+
+
+#  build-rpm:
+#    runs-on: ubuntu-latest
+#    container:
+#      image: centos:7
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Build RPM package
+#        run: |
+#          yum install -y python3 python3-pip rpm-build
+#          python3 setup.py bdist_rpm
+#      - name: Upload RPM artifact
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: rpm-package
+#          path: dist/*.rpm
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,75 +1,68 @@
 name: release
-on: push # test
-
-#on:
+on: [push]
 #  push:
 #    # run only against tags
 #    tags:
 #      - "*"
 
-
 jobs:
-  build-wheel:
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:jammy
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: |
-          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
-          python3 -V
-
-      - name: Build wheel package
-        run: |
-          python3 setup.py bdist_wheel
-
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v3
-        with:
-          # name: alpamon-${{ github.ref_name }}-py3-none-any.whl
-          # path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
-          name: alpamon-1.1.4-py3-none-any.whl
-          path: dist/alpamon-1.1.4-py3-none-any.whl
-
-  release:
-    runs-on: ubuntu-latest
-    container:
-      image: alpacanetworks/alpacon-cli:latest
-      options: --entrypoint ""
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download wheel artifact
-        uses: actions/download-artifact@v3
-        with:
-          # name: alpamon-${{ github.ref_name }}-py3-none-any.whl
-          name: alpamon-1.1.4-py3-none-any.whl
-
-      - name: List downloaded files
-        run: ls
-
-      - name: Release to alpacon.io
-        run: |
-          alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
-          alpacon package python upload alpamon-1.1.4-py3-none-any.whl
-#           alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl
-
-#  build-rpm:
+#  build-wheel:
 #    runs-on: ubuntu-latest
 #    container:
-#      image: centos:7
+#      image: ubuntu:jammy
 #    steps:
-#      - uses: actions/checkout@v4
-#      - name: Build RPM package
+#      - uses: actions/checkout@v3
+#
+#      - name: Install dependencies
 #        run: |
-#          yum install -y python3 python3-pip rpm-build
-#          python3 setup.py bdist_rpm
-#      - name: Upload RPM artifact
+#          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+#          python3 -V
+#
+#      - name: Build wheel package
+#        run: |
+#          python3 setup.py bdist_wheel
+#
+#      - name: Upload wheel artifact
 #        uses: actions/upload-artifact@v3
 #        with:
-#          name: rpm-package
-#          path: dist/*.rpm
+#          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+#          path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
+#
+#  release:
+#    runs-on: ubuntu-latest
+#    container:
+#      image: alpacanetworks/alpacon-cli:latest
+#      options: --entrypoint ""
+#    steps:
+#      - uses: actions/checkout@v3
+#
+#      - name: List downloaded files
+#        run: ls
+#
+#      - name: Download wheel artifact
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+#
+#      - name: Release to alpacon.io
+#        run: |
+#          alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
+#          alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build RPM package
+        run: |
+          yum install -y python3 python3-pip rpm-build
+          python3 setup.py bdist_rpm
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: alpamon-1.1.4-1.noarch.rpm
+          path: dist/alpamon-1.1.4-1.noarch.rpm
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,53 +1,32 @@
 name: release
-on: [push]
-#  push:
-#    # run only against tags
-#    tags:
-#      - "*"
+on:
+  push:
+    # run only against tags
+    tags:
+      - "*"
 
 jobs:
-#  build-wheel:
-#    runs-on: ubuntu-latest
-#    container:
-#      image: ubuntu:jammy
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: Install dependencies
-#        run: |
-#          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
-#          python3 -V
-#
-#      - name: Build wheel package
-#        run: |
-#          python3 setup.py bdist_wheel
-#
-#      - name: Upload wheel artifact
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
-#          path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
-#
-#  release:
-#    runs-on: ubuntu-latest
-#    container:
-#      image: alpacanetworks/alpacon-cli:latest
-#      options: --entrypoint ""
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - name: List downloaded files
-#        run: ls
-#
-#      - name: Download wheel artifact
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
-#
-#      - name: Release to alpacon.io
-#        run: |
-#          alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
-#          alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl
+  build-wheel:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          apt-get update -q && apt-get install -y --no-install-recommends python3-pip python3-setuptools
+          python3 -V
+
+      - name: Build wheel package
+        run: |
+          python3 setup.py bdist_wheel
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+          path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
 
   build-rpm:
     runs-on: ubuntu-latest
@@ -55,14 +34,42 @@ jobs:
       image: centos:7
     steps:
       - uses: actions/checkout@v3
-      - name: Build RPM package
+
+      - name: Install dependencies
         run: |
           yum install -y python3 python3-pip rpm-build
+
+      - name: Build RPM package
+        run: |
           python3 setup.py bdist_rpm
+
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v3
         with:
-          name: alpamon-1.1.4-1.noarch.rpm
-          path: dist/alpamon-1.1.4-1.noarch.rpm
+          name: alpamon-${{ github.ref_name }}-1.noarch.rpm
+          path: dist/alpamon-${{ github.ref_name }}-1.noarch.rpm
+
+  release:
+    runs-on: ubuntu-latest
+    container:
+      image: alpacanetworks/alpacon-cli:latest
+      options: --entrypoint ""
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: List downloaded files
+        run: ls
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: alpamon-${{ github.ref_name }}-py3-none-any.whl
+
+      - name: Release to alpacon.io
+        run: |
+          alpacon login -s ${{ secrets.ALPACON_URL }} -t ${{ secrets.ALPACON_TOKEN }}
+          alpacon package python upload alpamon-${{ github.ref_name }}-py3-none-any.whl
+          alpacon package python upload alpamon-${{ github.ref_name }}-1.noarch.rpm
+
 
 


### PR DESCRIPTION
close #7 

### Description
A `GitHub action` has been added, performing the same functions as the previously established `GitLab CI`, with the added capability of uploading rpm packages to `alpacon.io`.

### Details
- `build-and-test.yml`: Conducts tests across various Ubuntu distributions.

- `release.yml`: Activates only during releases or tagging, uploading artifacts as previously done and utilizing `alpacon-cli` to upload Python packages.


### Issues
- The use of `actions/checkout@v4` leads to a "GLIBC_2.27' not found" error, thus `v3` is employed. For more details refer to [actions/checkout#1487](https://github.com/actions/checkout/issues/1487)
- `artifact@v4` also shows similar errors frequently, necessitating the use of `v3`.