### PR TITLE
Fix trigger release job only after successful build and test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,13 @@
 name: Build and Test
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [main]
+    
+  pull_request:
+    types: [opened, ready_for_review]
+
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,9 @@ on:
 
   workflow_call:
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    # run only against tags
     tags:
       - "*"
 
@@ -12,7 +11,6 @@ jobs:
   build-wheel:
     needs: [build-and-test]
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:
       image: ubuntu:jammy
     steps:
@@ -36,7 +34,6 @@ jobs:
   build-rpm:
     needs: [build-and-test]
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:
       image: centos:7
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,18 @@
-name: release
+name: Release
 on:
   push:
     # run only against tags
     tags:
       - "*"
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
 
 jobs:
   build-wheel:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:
       image: ubuntu:jammy
     steps:
@@ -30,6 +35,7 @@ jobs:
 
   build-rpm:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:
       image: centos:7
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,13 @@ on:
     # run only against tags
     tags:
       - "*"
-  workflow_run:
-    workflows: ["Build and Test"]
-    types:
-      - completed
 
 jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    
   build-wheel:
+    needs: [build-and-test]
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:
@@ -34,6 +34,7 @@ jobs:
           path: dist/alpamon-${{ github.ref_name }}-py3-none-any.whl
 
   build-rpm:
+    needs: [build-and-test]
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     container:


### PR DESCRIPTION
Fixed an issue where the Release job would run even if the Build and Test job failed. Now, the Release job will only execute after both Build and Test jobs are successful.

This was resolved by using workflow_call to trigger the build-and-test workflow from the release job, adding an extra verification step.

Also, fixed the `GLIBC_2.28` not found error on Ubuntu 18.04 and lower versions. Added an env variable to allow the use of an unsecure Node version to resolve this issue.

Reference: https://github.com/actions/checkout/issues/1590