### PR TITLE
Resolve "Old Interface Address Deletion Issue"

### DIFF
--- a/alpamon/runner/commit.py
+++ b/alpamon/runner/commit.py
@@ -271,7 +271,6 @@ def sync_system_info(session, keys=[]):
             for item in delete_data.values():
                 rqueue.delete(
                     entry['url'] + item['id'] + '/',
-                    json=item['data'],
                     priority=80,
                 )
 


### PR DESCRIPTION
This pull request resolve [this issue](https://github.com/alpacanetworks/alpamon/issues/25).

### Changes:

- 413 Error occurred when sending JSON data with delete request to delete system information, which caused the system information to not synchronize properly.

  - To resolve this, Removed the JSON parameter at delete request.